### PR TITLE
CDK-305 Adding user to the 'root' group as a workaround for unwritabl…

### DIFF
--- a/recipes/stack-base/centos/Dockerfile
+++ b/recipes/stack-base/centos/Dockerfile
@@ -30,7 +30,8 @@ RUN yum -y update && \
     sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config && \
     sed -ri 's/#UsePAM no/UsePAM no/g' /etc/ssh/sshd_config && \
     echo "%wheel ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,wheel -d /home/user --shell /bin/bash -m user && \
+    # Adding user to the 'root' is a workaround for https://issues.jboss.org/browse/CDK-305
+    useradd -u 1000 -G users,wheel,root -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
     sed -i 's/requiretty/!requiretty/g' /etc/sudoers
 

--- a/recipes/stack-base/debian/Dockerfile
+++ b/recipes/stack-base/debian/Dockerfile
@@ -29,7 +29,8 @@ RUN echo "deb http://http.debian.net/debian jessie-backports main" >> /etc/apt/s
     mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    # Adding user to the 'root' is a workaround for https://issues.jboss.org/browse/CDK-305
+    useradd -u 1000 -G users,sudo,root -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
     sudo echo -e "deb http://ppa.launchpad.net/git-core/ppa/ubuntu precise main\ndeb-src http://ppa.launchpad.net/git-core/ppa/ubuntu precise main" >> /etc/apt/sources.list.d/sources.list && \
     sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys A1715D88E1DF1F24 && \

--- a/recipes/stack-base/ubuntu/Dockerfile
+++ b/recipes/stack-base/ubuntu/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && \
     mkdir /var/run/sshd && \
     sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd && \
     echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers && \
-    useradd -u 1000 -G users,sudo -d /home/user --shell /bin/bash -m user && \
+    # Adding user to the 'root' is a workaround for https://issues.jboss.org/browse/CDK-305
+    useradd -u 1000 -G users,sudo,root -d /home/user --shell /bin/bash -m user && \
     usermod -p "*" user && \
     add-apt-repository ppa:git-core/ppa && \
     add-apt-repository ppa:openjdk-r/ppa && \


### PR DESCRIPTION
…e pvs owned by root on minishift / origin

Signed-off-by: Ilya Buziuk <ibuziuk@redhat.com>

### What does this PR do?

### What issues does this PR fix or reference?

### Previous behavior
(Remove this section if not relevant)

### New behavior
(Explain the PR as it should appear in the release notes)

Please review [Che's Contributing Guide](https://github.com/eclipse/che/blob/master/CONTRIBUTING.md) for best practices.

### Tests written?
Yes/No

### Docs updated?
Please add a matching PR to [the docs repo](http://github.com/eclipse/che-docs) and link that PR to this issue. Both will be merged at the same time. 
